### PR TITLE
Allow to specify any garoon user ID

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/joho/godotenv"
 	"github.com/otoyo/garoon"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/api/calendar/v3"
-	"os"
-	"regexp"
-	"strings"
-	"time"
 )
 
 func main() {
@@ -73,8 +74,7 @@ func main() {
 		{
 			Name:  "sync",
 			Usage: "sync",
-			Flags: []cli.Flag{
-			},
+			Flags: []cli.Flag{},
 			Action: func(c *cli.Context) error {
 				grnUrl := c.String("grn-url")
 				var client *garoon.Client

--- a/main.go
+++ b/main.go
@@ -27,6 +27,11 @@ func main() {
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:    "grn-user-id",
+			Usage:   "garoon target[ user id",
+			EnvVars: []string{"GAROON_USER_ID"},
+		},
+		&cli.StringFlag{
 			Name:     "grn-pass",
 			Usage:    "garoon login password",
 			EnvVars:  []string{"GAROON_PASS"},
@@ -111,7 +116,7 @@ func main() {
 				//	panic(err)
 				//}
 
-				grnEvents, err := grn.EventsByUser(start, end, "661")
+				grnEvents, err := grn.EventsByUser(start, end, c.String("grn-user-id"))
 				if err != nil {
 					panic(err)
 				}

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:    "grn-user-id",
-			Usage:   "garoon target[ user id",
+			Usage:   "garoon target user id",
 			EnvVars: []string{"GAROON_USER_ID"},
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
I've found that the fixed garoon user ID has been hard-coded in the program.
To solve this issue, I added `--grn-user-id` flag to specify any garoon user ID.